### PR TITLE
Plasma 6.6 compatibility: replace PagerModel with VirtualDesktopInfo

### DIFF
--- a/contents/ui/RepresentationRectangle.qml
+++ b/contents/ui/RepresentationRectangle.qml
@@ -57,8 +57,9 @@ Rectangle {
 
     MouseArea {
         id: mouseArea
+        z: 10
         anchors.fill: parent
-        onClicked: virtualDesktopInfo.requestActivate(virtualDesktopInfo.desktopIds[pos])
+        onClicked: root.activateDesktop(pos)
         acceptedButtons: Qt.LeftButton
         hoverEnabled: true
     }

--- a/contents/ui/RepresentationRectangle.qml
+++ b/contents/ui/RepresentationRectangle.qml
@@ -58,7 +58,7 @@ Rectangle {
     MouseArea {
         id: mouseArea
         anchors.fill: parent
-        onClicked: pagerModel.changePage(pos)
+        onClicked: virtualDesktopInfo.requestActivate(virtualDesktopInfo.desktopIds[pos])
         acceptedButtons: Qt.LeftButton
         hoverEnabled: true
     }

--- a/contents/ui/ScrllHndl.qml
+++ b/contents/ui/ScrllHndl.qml
@@ -1,13 +1,14 @@
 import QtQuick
 import QtQuick.Layouts
 import org.kde.plasma.plasma5support as Plasma5Support
+import "./Utils.js" as Utils
 
 MouseArea {
     property int wheelDelta : 0
 
     acceptedButtons: Qt.MiddleButton
     //Open Grid View on middle Click
-    onClicked: executable.connectSource('qdbus org.kde.kglobalaccel /component/kwin invokeShortcut \"Grid View\"')
+    onClicked: executable.connectSource(Utils.qdbusRun("org.kde.kglobalaccel", "/component/kwin", "org.kde.kglobalaccel.Component.invokeShortcut", ["Grid View"]))
 
     //Scroll Handler
     onWheel : wheel => {
@@ -23,13 +24,15 @@ MouseArea {
         }
         while (increment !== 0) {
             if (increment < 0) {
-                const nextPage = cfg.wrapOn? (curr_page + 1) % pagerModel.count :
-                Math.min(curr_page + 1, pagerModel.count - 1);
-                pagerModel.changePage(nextPage);
+                const count = virtualDesktopInfo.numberOfDesktops;
+                const nextPage = cfg.wrapOn? (curr_page + 1) % count :
+                Math.min(curr_page + 1, count - 1);
+                virtualDesktopInfo.requestActivate(virtualDesktopInfo.desktopIds[nextPage]);
             } else {
-                const previousPage = cfg.wrapOn? (pagerModel.count + curr_page - 1) % pagerModel.count :
+                const count = virtualDesktopInfo.numberOfDesktops;
+                const previousPage = cfg.wrapOn? (count + curr_page - 1) % count :
                 Math.max(curr_page - 1, 0);
-                pagerModel.changePage(previousPage);
+                virtualDesktopInfo.requestActivate(virtualDesktopInfo.desktopIds[previousPage]);
             }
             increment += (increment < 0) ? 1 : -1;
             wheelDelta = 0;

--- a/contents/ui/Utils.js
+++ b/contents/ui/Utils.js
@@ -1,5 +1,20 @@
 //Roman numerals 1..=50
 
+// Escape string for use inside double quotes in shell
+function shellEscape(str) {
+    return String(str).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+// Run qdbus command (uses qdbus6 or qdbus, whichever is available)
+function qdbusCommand(method, args) {
+    var escaped = args.map(function(a) { return '"' + shellEscape(a) + '"'; });
+    return "sh -c 'QDBUS=$(command -v qdbus6 || command -v qdbus) && exec $QDBUS org.kde.KWin /VirtualDesktopManager org.kde.KWin.VirtualDesktopManager." + method + " " + escaped.join(" ") + "'";
+}
+// Generic qdbus runner for any service (service, path, interface.method, [args])
+function qdbusRun(service, path, ifaceMethod, args) {
+    var escaped = (args || []).map(function(a) { return '"' + shellEscape(a) + '"'; });
+    return "sh -c 'QDBUS=$(command -v qdbus6 || command -v qdbus) && exec $QDBUS " + service + " " + path + " " + ifaceMethod + (escaped.length ? " " + escaped.join(" ") : "") + "'";
+}
+
 const ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX",
     "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX",
     "XXI", "XXII", "XXIII", "XXIV", "XXV", "XXVI", "XXVII", "XXVIII", "XXIX", "XXX",

--- a/contents/ui/Utils.js
+++ b/contents/ui/Utils.js
@@ -14,6 +14,10 @@ function qdbusRun(service, path, ifaceMethod, args) {
     var escaped = (args || []).map(function(a) { return '"' + shellEscape(a) + '"'; });
     return "sh -c 'QDBUS=$(command -v qdbus6 || command -v qdbus) && exec $QDBUS " + service + " " + path + " " + ifaceMethod + (escaped.length ? " " + escaped.join(" ") : "") + "'";
 }
+// Activate virtual desktop by ID (via DBus Properties.Set)
+function qdbusActivateDesktop(desktopId) {
+    return qdbusRun("org.kde.KWin", "/VirtualDesktopManager", "org.freedesktop.DBus.Properties.Set", ["org.kde.KWin.VirtualDesktopManager", "current", String(desktopId)]);
+}
 
 const ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX",
     "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX",

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -36,6 +36,9 @@ PlasmoidItem {
         connectedSources: []
         onNewData: disconnectSource(sourceName)
     }
+    function activateDesktop(pos) {
+        dbusExecutable.connectSource(Utils.qdbusActivateDesktop(virtualDesktopInfo.desktopIds[pos]))
+    }
     TaskManager.ActivityInfo { id: activityInfo }
     Activities.ActivityInfo { id: fullActivityInfo; activityId: ":current" }
 


### PR DESCRIPTION
- Remove org.kde.plasma.private.pager dependency (no longer in Plasma 6.6)
- Use TaskManager.VirtualDesktopInfo for desktop count, current page, activate
- Add/Remove Virtual Desktop via KWin DBus (requestCreateDesktop unreliable)
- Auto-detect qdbus6 vs qdbus for cross-distro compatibility
- Update ScrllHndl Grid View to use same qdbus detection