### PR TITLE
Fix install script for KDE Neon.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,8 +29,8 @@ cat > "$ENV_FILE" << EOF
 export PATH="\$HOME/.local/bin:\$PATH"
 export XDG_DATA_DIRS="\$HOME/.local/share:\${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 export XDG_CONFIG_DIRS="\$HOME/.local/etc/xdg:\${XDG_CONFIG_DIRS:-/etc/xdg}"
-export QML2_IMPORT_PATH="\$HOME/.local/lib/qml:\${QML2_IMPORT_PATH}"
-export QT_PLUGIN_PATH="\$HOME/.local/lib/plugins:\${QT_PLUGIN_PATH}"
+export QML2_IMPORT_PATH="\$HOME/.local/lib/qml:\$HOME/.local/lib/x86_64-linux-gnu/qml:${QML2_IMPORT_PATH}"
+export QT_PLUGIN_PATH="\$HOME/.local/lib/plugins:\$HOME/.local/lib/x86_64-linux-gnu/plugins):\${QT_PLUGIN_PATH}"
 EOF
 
 # Make it executable


### PR DESCRIPTION
This shouldn't break anything elsewhere; it may be needed on ubuntu and debian based systems as well.

Tested to work on KDE Neon and not to break anything on Arch.