### PR TITLE
Fix QML module path: add lib64 for 64-bit systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,8 +29,8 @@ cat > "$ENV_FILE" << EOF
 export PATH="\$HOME/.local/bin:\$PATH"
 export XDG_DATA_DIRS="\$HOME/.local/share:\${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 export XDG_CONFIG_DIRS="\$HOME/.local/etc/xdg:\${XDG_CONFIG_DIRS:-/etc/xdg}"
-export QML2_IMPORT_PATH="\$HOME/.local/lib/qml:\${QML2_IMPORT_PATH}"
-export QT_PLUGIN_PATH="\$HOME/.local/lib/plugins:\${QT_PLUGIN_PATH}"
+export QML2_IMPORT_PATH="\$HOME/.local/lib64/qml:\$HOME/.local/lib/qml:\${QML2_IMPORT_PATH}"
+export QT_PLUGIN_PATH="\$HOME/.local/lib64/plugins:\$HOME/.local/lib/plugins:\${QT_PLUGIN_PATH}"
 EOF
 
 # Make it executable


### PR DESCRIPTION
Fixes install.sh for 64-bit systems.
At least for my Fedora 43 this was needed