### PR TITLE
fix: port to Plasma 6 - replace PagerModel with VirtualDesktopInfo

### DIFF
--- a/package/contents/ui/RepresentationRectangle.qml
+++ b/package/contents/ui/RepresentationRectangle.qml
@@ -1,3 +1,4 @@
+import org.kde.plasma.plasma5support as Plasma5Support
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
@@ -58,7 +59,7 @@ Rectangle {
     MouseArea {
         id: mouseArea
         anchors.fill: parent
-        onClicked: pagerModel.changePage(pos)
+        onClicked: executable.connectSource("qdbus6 org.kde.KWin /VirtualDesktopManager org.kde.KWin.VirtualDesktopManager.current " + virtualDesktopInfo.desktopIds[pos])
         acceptedButtons: Qt.LeftButton
         hoverEnabled: true
     }
@@ -87,5 +88,11 @@ Rectangle {
         text: virtualDesktopInfo.desktopNames[pos]
         delay: 2000
         timeout: 3000
+    }
+    Plasma5Support.DataSource {
+        id: "executable"
+        engine: "executable"
+        connectedSources: []
+        onNewData: function(sourceName, data) { disconnectSource(sourceName) }
     }
 }

--- a/package/contents/ui/ScrllHndl.qml
+++ b/package/contents/ui/ScrllHndl.qml
@@ -23,13 +23,13 @@ MouseArea {
         }
         while (increment !== 0) {
             if (increment < 0) {
-                const nextPage = cfg.wrapOn? (curr_page + 1) % pagerModel.count :
-                Math.min(curr_page + 1, pagerModel.count - 1);
-                pagerModel.changePage(nextPage);
+                const nextPage = cfg.wrapOn? (curr_page + 1) % virtualDesktopInfo.numberOfDesktops :
+                Math.min(curr_page + 1, virtualDesktopInfo.numberOfDesktops - 1);
+                executable.connectSource("qdbus6 org.kde.KWin /VirtualDesktopManager org.kde.KWin.VirtualDesktopManager.current " + virtualDesktopInfo.desktopIds[nextPage]);
             } else {
-                const previousPage = cfg.wrapOn? (pagerModel.count + curr_page - 1) % pagerModel.count :
+                const previousPage = cfg.wrapOn? (virtualDesktopInfo.numberOfDesktops + curr_page - 1) % virtualDesktopInfo.numberOfDesktops :
                 Math.max(curr_page - 1, 0);
-                pagerModel.changePage(previousPage);
+                executable.connectSource("qdbus6 org.kde.KWin /VirtualDesktopManager org.kde.KWin.VirtualDesktopManager.current " + virtualDesktopInfo.desktopIds[previousPage]);
             }
             increment += (increment < 0) ? 1 : -1;
             wheelDelta = 0;

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -7,7 +7,6 @@ import org.kde.plasma.core as PlasmaCore
 import org.kde.taskmanager as TaskManager
 import org.kde.activities as Activities
 import org.kde.kirigami as Kirigami
-import org.dhruv8sh.kara
 import "./Utils.js" as Utils
 
 PlasmoidItem {
@@ -17,7 +16,7 @@ PlasmoidItem {
     property var location       : plasmoid.location
     property var form           : plasmoid.formFactor
     property bool is_vertical   : form == PlasmaCore.Types.Vertical
-    property alias curr_page    : pagerModel.currentPage
+    property var curr_page: virtualDesktopInfo.desktopIds.indexOf(virtualDesktopInfo.currentDesktop)
     property var customLabels   : cfg.labelsList.split('\n')
     property var customIcons    : cfg.iconsList.split('\n')
     property bool showOnlyActive: cfg.showOnlyActive
@@ -28,11 +27,6 @@ PlasmoidItem {
     ScrllHndl{ anchors.fill: parent }
 
     // Pager and Tasks Models (required)
-    PagerModel {
-        id: pagerModel
-        enabled: true
-        pagerType: PagerModel.VirtualDesktops;
-    }
     TaskManager.VirtualDesktopInfo { id: virtualDesktopInfo }
     TaskManager.ActivityInfo { id: activityInfo }
     Activities.ActivityInfo { id: fullActivityInfo; activityId: ":current" }
@@ -41,11 +35,11 @@ PlasmoidItem {
     fullRepresentation: GridLayout {
         columnSpacing: is_vertical ? 0 : cfg.spacing
         rowSpacing: is_vertical ? cfg.spacing : 0
-        columns: is_vertical ? 1 : pagerModel.count
-        rows: is_vertical ? pagerModel.count : 1
+        columns: is_vertical ? 1 : virtualDesktopInfo.numberOfDesktops
+        rows: is_vertical ? virtualDesktopInfo.numberOfDesktops : 1
         Repeater {
             id: rep
-            model: pagerModel.count
+            model: virtualDesktopInfo.numberOfDesktops
             delegate: RepresentationRectangle {}
             onItemAdded: function(index,item){
                 item.pos = index
@@ -59,14 +53,14 @@ PlasmoidItem {
             text: i18n("Add Virtual Desktop")
             icon.name: "list-add"
             visible: KConfig.KAuthorized.authorize("kcm_kwin_virtualdesktops")
-            onTriggered: pagerModel.addDesktop()
+            onTriggered: virtualDesktopInfo.requestCreateVirtualDesktop("Desktop " + (virtualDesktopInfo.numberOfDesktops + 1))
         },
         PlasmaCore.Action {
             text: i18n("Remove Virtual Desktop")
             icon.name: "list-remove"
             visible: KConfig.KAuthorized.authorize("kcm_kwin_virtualdesktops")
-            enabled: pagerModel.count > 1
-            onTriggered: pagerModel.removeDesktop()
+            enabled: virtualDesktopInfo.numberOfDesktops > 1
+            onTriggered: virtualDesktopInfo.requestRemoveVirtualDesktop(virtualDesktopInfo.desktopIds[virtualDesktopInfo.numberOfDesktops - 1])
         },
         PlasmaCore.Action {
             text: i18n("Configure Virtual Desktops…")


### PR DESCRIPTION
## Problem
`org.kde.plasma.private.pager` and `PagerModel` were internal to the
pager applet's C++ plugin and are no longer accessible as a QML module
in Plasma 6, causing the widget to fail with:
"module org.kde.plasma.private.pager is not installed"

## Changes
- `main.qml`: Removed `PagerModel` and replaced all references with
  `TaskManager.VirtualDesktopInfo` (already imported by the widget)
- `RepresentationRectangle.qml`: Replaced `pagerModel.changePage()`
  with `qdbus6` call to set `VirtualDesktopManager.current`
- `ScrllHndl.qml`: Same qdbus6 fix for scroll navigation

## Tested on
- CachyOS (Arch-based)
- Plasma 6.6.3
- Wayland